### PR TITLE
アクセス制限実装

### DIFF
--- a/frontend/middleware/authenticated.js
+++ b/frontend/middleware/authenticated.js
@@ -1,0 +1,6 @@
+// 未ログインユーザーはログインページへリダイレクト
+export default function ({ store, redirect }) {
+  if (!store.getters['auth/isAuthenticated']) {
+    return redirect('/auth/signin')
+  }
+}

--- a/frontend/pages/auth/mypage.vue
+++ b/frontend/pages/auth/mypage.vue
@@ -111,11 +111,24 @@ export default {
     memory,
   },
   layout: 'loggedIn',
+  fetch({
+    store,
+    redirect
+  }) {
+    store.watch(
+      state => state.auth.currentUser,
+      (newUser, oldUser) => {
+        if (!newUser) {
+          return redirect('/auth/signin')
+        }
+      }
+    )
+  },
   computed: {
     user() {
       return this.$store.state.auth.currentUser
     }
-  },
+  }
 }
 </script>
 

--- a/frontend/pages/auth/signin.vue
+++ b/frontend/pages/auth/signin.vue
@@ -86,6 +86,24 @@ export default {
       error: null,
     }
   },
+  fetch({
+    store,
+    redirect
+  }) {
+    store.watch(
+      state => state.auth.currentUser,
+      (newUser, oldUser) => {
+        if (newUser) {
+          return redirect('/auth/mypage')
+        }
+      }
+    )
+  },
+  computed: {
+    user() {
+      return this.$store.state.auth.currentUser
+    }
+  },
   methods: {
     async signIn () {
       this.error = null

--- a/frontend/pages/auth/signup.vue
+++ b/frontend/pages/auth/signup.vue
@@ -116,6 +116,19 @@ export default {
       ]
     }
   },
+  fetch({
+    store,
+    redirect
+  }) {
+    store.watch(
+      state => state.auth.currentUser,
+      (newUser, oldUser) => {
+        if (newUser) {
+          return redirect('/auth/mypage')
+        }
+      }
+    )
+  },
   computed: {
     emailForm () {
       const placeholder = this.noValidation ? undefined : 'sample@sample.com'
@@ -165,6 +178,6 @@ export default {
       await this.$axios.$post('/v1/users', {user})
       this.$router.push('/auth/mypage')
     }
-  }
+  },
 }
 </script>

--- a/frontend/store/auth.js
+++ b/frontend/store/auth.js
@@ -1,6 +1,6 @@
 export const state = () => ({
   loggedIn: false,
-  currentUser: null,
+  currentUser: {},
   styles: {
     beforeLogin: {
       appBarHeight: 56,


### PR DESCRIPTION
close #25

## 実装内容
下記制限を実装
- ログイン時：アカウント登録ページ/ログインページにアクセスするとマイページへリダイレクト
- 未ログイン時：マイページにアクセスするとログインページへリダイレクト

## チェック項目
全体
- [x]  ローカル環境での動作に問題無いこと