### PR TITLE
フォロー/フォロワー機能実装

### DIFF
--- a/backend/app/controllers/v1/relationships_controller.rb
+++ b/backend/app/controllers/v1/relationships_controller.rb
@@ -1,0 +1,25 @@
+module V1
+  class RelationshipsController < ApplicationController
+    before_action :set_user
+    def create
+      user = @current_user.follow(@other_user)
+      render json: user
+    end
+
+    def destroy
+      user = @current_user.unfollow(@other_user)
+      if user.destroy
+        render json: user
+      else
+        render json: user.errors
+      end
+    end
+
+    private
+
+    def set_user
+      @current_user = User.find(params[:user_id])
+      @other_user = User.find(params[:follow_id])
+    end
+  end
+end

--- a/backend/app/controllers/v1/users_controller.rb
+++ b/backend/app/controllers/v1/users_controller.rb
@@ -9,9 +9,22 @@ module V1
       render json: users
     end
 
+    # def show
+    #   user = User.find(params[:id])
+    #   render json: user
+    # end
+
     def show
-      user = User.find(params[:id])
-      render json: user
+      user = User.includes(
+        :following,
+        :followers
+      )
+      render json: user.as_json(
+        include: [
+          :following,
+          :followers
+        ]
+      )
     end
 
     def create

--- a/backend/app/controllers/v1/users_controller.rb
+++ b/backend/app/controllers/v1/users_controller.rb
@@ -18,7 +18,7 @@ module V1
       user = User.includes(
         :following,
         :followers
-      )
+      ).find(params[:id])
       render json: user.as_json(
         include: [
           :following,

--- a/backend/app/models/relationship.rb
+++ b/backend/app/models/relationship.rb
@@ -1,0 +1,2 @@
+class Relationship < ApplicationRecord
+end

--- a/backend/app/models/relationship.rb
+++ b/backend/app/models/relationship.rb
@@ -1,2 +1,7 @@
 class Relationship < ApplicationRecord
+  belongs_to :follower, class_name: 'User'
+  belongs_to :followed, class_name: 'User'
+
+  validates :follower_id, presence: true
+  validates :followed_id, presence: true
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -2,4 +2,28 @@ class User < ApplicationRecord
   mount_uploader :avatar, AvatarUploader
   has_many :posts, dependent: :destroy
   has_many :reviews, dependent: :destroy
+  has_many :active_relationships, class_name: 'Relationship', foreign_key: 'follower_id', dependent: :destroy
+  has_many :passive_relationships, class_name: 'Relationship', foreign_key: 'followed_id', dependent: :destroy
+  has_many :following, through: :active_relationships, source: :followed
+  has_many :followers, through: :passive_relationships, source: :follower
+
+  # ユーザーをフォローする
+  def follow(other_user)
+    following << other_user
+  end
+
+  # ユーザーをフォロー解除する
+  def unfollow(other_user)
+    active_relationships.find_by(followed_id: other_user.id).destroy
+  end
+
+  # 現在のユーザーがフォローしてたらtrueを返す
+  def following?(other_user)
+    following.include?(other_user)
+  end
+
+  # 現在のユーザーがふぉろーされてたらtrueを返す
+  def followers?(other_user)
+    followers.include?(other_user)
+  end
 end

--- a/backend/app/serializers/user_serializer.rb
+++ b/backend/app/serializers/user_serializer.rb
@@ -1,4 +1,4 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :name, :email, :profile, :favorite_beer, :avatar
+  attributes :id, :name, :email, :profile, :favorite_beer, :avatar, :following, :followers
   has_many :posts
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -71,10 +71,13 @@ Rails.application.routes.draw do
     get 'beers/okinawa'
     resources :beers, only: %i[index show]
 
-    # post 関連
+    # posts 関連
     resources :posts, only: %i[index show create update destroy]
 
     # reviews 関連
     resources :posts, only: %i[index create destroy]
+
+    # relationships 関連
+    resources :relationships, only: %i[create destroy]
   end
 end

--- a/backend/db/migrate/20220520130646_create_relationships.rb
+++ b/backend/db/migrate/20220520130646_create_relationships.rb
@@ -1,0 +1,13 @@
+class CreateRelationships < ActiveRecord::Migration[6.1]
+  def change
+    create_table :relationships do |t|
+      t.integer :follower_id
+      t.integer :followed_id
+
+      t.timestamps
+    end
+    add_index :relationships, :follower_id
+    add_index :relationships, :followed_id
+    add_index :relationships, [:follower_id, :followed_id], unique: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_14_071856) do
+ActiveRecord::Schema.define(version: 2022_05_20_130646) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,16 @@ ActiveRecord::Schema.define(version: 2022_05_14_071856) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "image"
     t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "relationships", force: :cascade do |t|
+    t.integer "follower_id"
+    t.integer "followed_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["followed_id"], name: "index_relationships_on_followed_id"
+    t.index ["follower_id", "followed_id"], name: "index_relationships_on_follower_id_and_followed_id", unique: true
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
 
   create_table "reviews", force: :cascade do |t|

--- a/frontend/components/loggedIn/mypage/follow.vue
+++ b/frontend/components/loggedIn/mypage/follow.vue
@@ -1,3 +1,77 @@
 <template>
-  <div>フォロー</div>
+  <v-container>
+    <v-row
+      justify="center"
+    >
+      <v-col
+        v-for="(follow, i) in following"
+        :key="i"
+        cols="12"
+        xl="4"
+        lg="4"
+        sm="8"
+      >
+        <v-card
+          v-if="follow"
+        >
+          <v-container>
+            <v-card-title>
+              <v-container>
+                <v-row>
+                  <v-col
+                    cols="4"
+                  >
+                    <v-avatar
+                      size="64"
+                    >
+                      <img
+                        v-if="follow.avatar.url"
+                        :src="follow.avatar.url"
+                      />
+                      <img
+                        v-else
+                        :src="icon"
+                      />
+                    </v-avatar>
+                  </v-col>
+                  <v-col
+                    cols="8"
+                  >
+                    <h4>
+                      <nuxt-link
+                        :to="`/users/${follow.id}`"
+                      >
+                        {{ follow.name }}
+                      </nuxt-link>
+                    </h4>
+                  </v-col>
+                </v-row>
+              </v-container>
+            </v-card-title>
+          </v-container>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
+
+<script>
+export default {
+  props: {
+    following: {
+      type: Array,
+      default: () => {}
+    }
+  },
+  data () {
+    return {
+      icon: require("@/assets/images/other/default-user.png")
+    }
+  },
+  computed: {
+    user() {
+      return this.$store.state.auth.currentUser
+    }
+  },
+}
+</script>

--- a/frontend/components/loggedIn/mypage/follow.vue
+++ b/frontend/components/loggedIn/mypage/follow.vue
@@ -7,12 +7,14 @@
         v-for="(follow, i) in following"
         :key="i"
         cols="12"
-        xl="4"
-        lg="4"
+        xl="8"
+        lg="8"
         sm="8"
       >
         <v-card
           v-if="follow"
+          width="400"
+          class="mx-auto"
         >
           <v-container>
             <v-card-title>

--- a/frontend/components/loggedIn/mypage/follow.vue
+++ b/frontend/components/loggedIn/mypage/follow.vue
@@ -44,6 +44,7 @@
                         {{ follow.name }}
                       </nuxt-link>
                     </h4>
+                    <h6>{{ follow.profile }}</h6>
                   </v-col>
                 </v-row>
               </v-container>

--- a/frontend/components/loggedIn/mypage/follower.vue
+++ b/frontend/components/loggedIn/mypage/follower.vue
@@ -1,3 +1,78 @@
 <template>
-  <div>フォロワー</div>
+  <v-container>
+    <v-row
+      justify="center"
+    >
+      <v-col
+        v-for="(follower, i) in followers"
+        :key="i"
+        cols="12"
+        xl="4"
+        lg="4"
+        sm="8"
+      >
+        <v-card
+          v-if="follower"
+        >
+          <v-container>
+            <v-card-title>
+              <v-container>
+                <v-row>
+                  <v-col
+                    cols="4"
+                  >
+                    <v-avatar
+                      size="64"
+                    >
+                      <img
+                        v-if="follower.avatar.url"
+                        :src="follower.avatar.url"
+                      />
+                      <img
+                        v-else
+                        :src="icon"
+                      />
+                    </v-avatar>
+                  </v-col>
+                  <v-col
+                    cols="8"
+                  >
+                    <h4>
+                      <nuxt-link
+                        :to="`/users/${follower.id}`"
+                      >
+                        {{ follower.name }}
+                      </nuxt-link>
+                    </h4>
+                    <h6>{{ follower.profile }}</h6>
+                  </v-col>
+                </v-row>
+              </v-container>
+            </v-card-title>
+          </v-container>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
+
+<script>
+export default {
+  props: {
+    followers: {
+      type: Array,
+      default: () => {}
+    }
+  },
+  data () {
+    return {
+      icon: require("@/assets/images/other/default-user.png")
+    }
+  },
+  computed: {
+    user() {
+      return this.$store.state.auth.currentUser
+    }
+  },
+}
+</script>

--- a/frontend/pages/auth/mypage.vue
+++ b/frontend/pages/auth/mypage.vue
@@ -133,7 +133,11 @@
         <v-tab-item
           class="tab-item"
         >
-          <follower />
+          <div
+            v-if="user"
+          >
+            <follower :followers="user.followers"/>
+          </div>
         </v-tab-item>
         <v-tab-item
           class="tab-item"
@@ -165,6 +169,7 @@ export default {
     return {
       posts: [],
       following: [],
+      followers: [],
       guest: process.env.GUEST_EMAIL
     }
   },

--- a/frontend/pages/auth/mypage.vue
+++ b/frontend/pages/auth/mypage.vue
@@ -124,7 +124,11 @@
         <v-tab-item
           class="tab-item"
         >
-          <follow />
+          <div
+            v-if="user"
+          >
+            <follow :following="user.following"/>
+          </div>
         </v-tab-item>
         <v-tab-item
           class="tab-item"
@@ -160,6 +164,7 @@ export default {
   data () {
     return {
       posts: [],
+      following: [],
       guest: process.env.GUEST_EMAIL
     }
   },

--- a/frontend/pages/posts.vue
+++ b/frontend/pages/posts.vue
@@ -44,7 +44,18 @@
                       cols="8"
                     >
                       <h4>{{ post.title }}</h4>
-                      <h6>{{ post.username }} が {{ $moment(post.created_at).format('YYYY年MM月DD日 HH時mm分') }} に投稿</h6>
+                      <nuxt-link
+                        v-if="`${post.user_id}`!==`${user.id}`"
+                        :to="`users/${post.user_id}`"
+                      >
+                        <h6>{{ post.username }} が {{ $moment(post.created_at).format('YYYY年MM月DD日 HH時mm分') }} に投稿</h6>
+                      </nuxt-link>
+                      <nuxt-link
+                        v-else
+                        to="/auth/mypage"
+                      >
+                        <h6>{{ post.username }} が {{ $moment(post.created_at).format('YYYY年MM月DD日 HH時mm分') }} に投稿</h6>
+                      </nuxt-link>
                     </v-col>
                   </v-row>
                 </v-container>
@@ -115,6 +126,11 @@ export default{
   async fetch () {
     const posts = await this.$axios.$get('/v1/posts')
     this.posts = posts
+  },
+  computed: {
+    user() {
+      return this.$store.state.auth.currentUser
+    }
   },
 }
 </script>

--- a/frontend/pages/users/_id.vue
+++ b/frontend/pages/users/_id.vue
@@ -34,8 +34,8 @@
                       size="62"
                     >
                       <img
-                        v-if="otherUser.avatar_url"
-                        :src="otherUser"
+                        v-if="otherUser.avatar.url"
+                        :src="otherUser.avatar.url"
                       >
                       <img
                         v-else

--- a/frontend/pages/users/_id.vue
+++ b/frontend/pages/users/_id.vue
@@ -11,7 +11,7 @@
       >
         <v-card>
           <v-toolbar
-            color="cyan darken-1"
+            color="myorange lighten-1"
             dark
             flat
           >
@@ -93,7 +93,10 @@
                     </v-btn>
                     <v-btn
                       v-else
-                      color="white--text red"
+                      color="red"
+                      rounded
+                      outlined
+                      class="white--text"
                       @click="unfollow"
                     >
                       フォロー解除する
@@ -146,10 +149,26 @@ export default {
       setData: 'otherUser/setData'
     }),
     async follow() {
-
+      await this.$axios.$post('/v1/relationships', {
+        user_id: this.user.id,
+        follow_id: this.otherUser.id
+      })
+      await this.$axios.$get(`/v1/users/${this.$route.params.id}`)
+        .then(response => {
+          this.setData(response)
+        })
     },
     async unfollow() {
-
+      await this.$axios.$delete('/v1/relationships', {
+        params: {
+          user_id: this.user.id,
+          follow_id: this.otherUser.id
+        }
+      })
+      await this.$axios.$get(`/v1/users/${this.$route.params.id}`)
+        .then(response => {
+          this.setData(response)
+        })
     }
   }
 }

--- a/frontend/pages/users/_id.vue
+++ b/frontend/pages/users/_id.vue
@@ -173,7 +173,7 @@ export default {
         })
     },
     async unfollow() {
-      await this.$axios.$delete('/v1/relationships', {
+      await this.$axios.$delete('/v1/relationships/delete', {
         params: {
           user_id: this.user.id,
           follow_id: this.otherUser.id

--- a/frontend/pages/users/_id.vue
+++ b/frontend/pages/users/_id.vue
@@ -9,7 +9,9 @@
         lg="4"
         sm="8"
       >
-        <v-card>
+        <v-card
+          v-if="otherUser"
+        >
           <v-toolbar
             color="myorange lighten-1"
             dark
@@ -58,6 +60,15 @@
                     justify="center"
                   >
                     <p>{{ otherUser.profile }}</p>
+                  </v-row>
+                </v-col>
+                <v-col
+                  cols="12"
+                >
+                  <v-row
+                    justify="center"
+                  >
+                    <p>{{ otherUser.favorite_beer }}が好きです！！</p>
                   </v-row>
                 </v-col>
                 <v-col
@@ -130,6 +141,9 @@ export default {
   computed: {
     user() {
       return this.$store.state.auth.currentUser
+    },
+    otherUser() {
+      return this.$store.state.otherUser.otherUser
     },
     ...mapGetters({
       otherUser: 'otherUser/data'

--- a/frontend/pages/users/_id.vue
+++ b/frontend/pages/users/_id.vue
@@ -66,11 +66,11 @@
                   <v-row>
                     <v-col>
                       <p>フォロー</p>
-                      <!-- <p>{{ otherUser.following.length }}人</p> -->
+                      <p>{{ otherUser.following.length }}人</p>
                     </v-col>
                     <v-col>
                       <p>フォロワー</p>
-                      <!-- <p>{{ otherUser.followers.length }}人</p> -->
+                      <p>{{ otherUser.followers.length }}人</p>
                     </v-col>
                   </v-row>
                 </v-col>
@@ -118,19 +118,6 @@ export default {
       icon: require("@/assets/images/other/default-user.png")
     }
   },
-  // fetch({
-  //   store,
-  //   redirect
-  // }) {
-  //   store.watch(
-  //     state => state.auth.currentUser,
-  //     (newUser, oldUser) => {
-  //       if (!newUser) {
-  //         return redirect('/auth/signin')
-  //       }
-  //     }
-  //   )
-  // },
   async fetch({ $axios, params, store }) {
     await $axios.$get(`/v1/users/${params.id}`)
     .then(response => {
@@ -142,7 +129,7 @@ export default {
       return this.$store.state.auth.currentUser
     },
     ...mapGetters({
-      otherUser: 'otherUser/user'
+      otherUser: 'otherUser/data'
     }),
     myselfCheck () {
       if (this.$store.getters['auth/data'] === undefined) {

--- a/frontend/pages/users/_id.vue
+++ b/frontend/pages/users/_id.vue
@@ -66,11 +66,11 @@
                   <v-row>
                     <v-col>
                       <p>フォロー</p>
-                      <p>{{ otherUser.following.length }}人</p>
+                      <!-- <p>{{ otherUser.following.length }}人</p> -->
                     </v-col>
                     <v-col>
                       <p>フォロワー</p>
-                      <p>{{ otherUser.followers.length }}人</p>
+                      <!-- <p>{{ otherUser.followers.length }}人</p> -->
                     </v-col>
                   </v-row>
                 </v-col>
@@ -83,14 +83,17 @@
                   >
                     <v-btn
                       v-if="!otherUser.isFollowed"
-                      coloer="success"
+                      color="success"
+                      rounded
+                      outlined
+                      class="white--text"
                       @click="follow"
                     >
                       フォローする
                     </v-btn>
                     <v-btn
                       v-else
-                      collor="white--text red"
+                      color="white--text red"
                       @click="unfollow"
                     >
                       フォロー解除する
@@ -107,16 +110,60 @@
 </template>
 
 <script>
+import { mapGetters, mapActions } from 'vuex'
 export default {
+  layout: 'loggedIn',
   data () {
     return {
       icon: require("@/assets/images/other/default-user.png")
     }
   },
+  // fetch({
+  //   store,
+  //   redirect
+  // }) {
+  //   store.watch(
+  //     state => state.auth.currentUser,
+  //     (newUser, oldUser) => {
+  //       if (!newUser) {
+  //         return redirect('/auth/signin')
+  //       }
+  //     }
+  //   )
+  // },
+  async fetch({ $axios, params, store }) {
+    await $axios.$get(`/v1/users/${params.id}`)
+    .then(response => {
+      store.dispatch('otherUser/setData', response)
+    })
+  },
   computed: {
     user() {
       return this.$store.state.auth.currentUser
+    },
+    ...mapGetters({
+      otherUser: 'otherUser/user'
+    }),
+    myselfCheck () {
+      if (this.$store.getters['auth/data'] === undefined) {
+        return false
+      } else if (this.$store.getters['auth/data'].id === this.$store.getters['otherUser/data'].id) {
+          return false
+        } else {
+          return true
+        }
     }
   },
+  methods: {
+    ...mapActions({
+      setData: 'otherUser/setData'
+    }),
+    async follow() {
+
+    },
+    async unfollow() {
+
+    }
+  }
 }
 </script>

--- a/frontend/pages/users/_id.vue
+++ b/frontend/pages/users/_id.vue
@@ -86,31 +86,37 @@
                   </v-row>
                 </v-col>
                 <v-col
-                  v-if="myselfCheck"
+                  v-if="currentUser && currentUser.id !== user.id"
                   cols="12"
                 >
                   <v-row
                     justify="center"
                   >
                     <v-btn
-                      v-if="!otherUser.isFollowed"
+                      v-if="follow"
+                      :color="color"
+                      rounded
+                      outlined
+                      @click="unfollowUser"
+                      @mouseover="mouseover"
+                      @mouseleave="mouseleave"
+                    >
+                      {{ message }}
+                    </v-btn>
+                    <v-btn
+                      v-else
                       color="success"
                       rounded
                       outlined
                       class="white--text"
-                      @click="follow"
+                      @click="followUser"
                     >
                       フォローする
-                    </v-btn>
-                    <v-btn
-                      v-else
-                      color="red"
-                      rounded
-                      outlined
-                      class="white--text"
-                      @click="unfollow"
-                    >
-                      フォロー解除する
+                      <v-icon
+                        right
+                      >
+                        mdi-account-plus
+                      </v-icon>
                     </v-btn>
                   </v-row>
                 </v-col>
@@ -129,6 +135,9 @@ export default {
   layout: 'loggedIn',
   data () {
     return {
+      follow: false,
+      message: 'フォロー中',
+      color: 'success white--text',
       icon: require("@/assets/images/other/default-user.png")
     }
   },
@@ -139,14 +148,16 @@ export default {
     })
   },
   computed: {
-    user() {
+    userData() {
       return this.$store.state.auth.currentUser
     },
     otherUser() {
       return this.$store.state.otherUser.otherUser
     },
     ...mapGetters({
-      otherUser: 'otherUser/data'
+      otherUser: 'otherUser/data',
+      currentUser: 'auth/currentUser',
+      user: 'user/user'
     }),
     myselfCheck () {
       if (this.$store.getters['auth/data'] === undefined) {
@@ -158,30 +169,53 @@ export default {
         }
     }
   },
+  created() {
+    this.$axios.get(`/v1/users/${this.$route.params.id}`).then((response) => {
+      this.$store.commit('user/setUser', response.data, { root: true })
+      if (this.currentUser) {
+        this.follow = false
+        this.user.followers.forEach(f => {
+          if (f.id === this.currentUser.id) {
+            this.follow = true
+          }
+        })
+      }
+    })
+  },
   methods: {
     ...mapActions({
       setData: 'otherUser/setData'
     }),
-    async follow() {
+    mouseover() {
+      this.color = 'red white--text'
+      this.message = 'フォローを解除する'
+    },
+    mouseleave() {
+      this.color = 'success white--text'
+      this.message = 'フォロー中'
+    },
+    async followUser() {
       await this.$axios.$post('/v1/relationships', {
-        user_id: this.user.id,
+        user_id: this.userData.id,
         follow_id: this.otherUser.id
       })
       await this.$axios.$get(`/v1/users/${this.$route.params.id}`)
         .then(response => {
           this.setData(response)
+          location.reload()
         })
     },
-    async unfollow() {
+    async unfollowUser() {
       await this.$axios.$delete('/v1/relationships/delete', {
         params: {
-          user_id: this.user.id,
+          user_id: this.userData.id,
           follow_id: this.otherUser.id
         }
       })
       await this.$axios.$get(`/v1/users/${this.$route.params.id}`)
         .then(response => {
           this.setData(response)
+          location.reload()
         })
     }
   }

--- a/frontend/pages/users/_id.vue
+++ b/frontend/pages/users/_id.vue
@@ -1,0 +1,122 @@
+<template>
+  <v-container>
+    <v-row
+      justify="center"
+    >
+      <v-col
+        cols="12"
+        xl="4"
+        lg="4"
+        sm="8"
+      >
+        <v-card>
+          <v-toolbar
+            color="cyan darken-1"
+            dark
+            flat
+          >
+            <v-toolbar-title>
+              {{ otherUser.name }} さんのプロフィール
+            </v-toolbar-title>
+          </v-toolbar>
+          <v-card-text>
+            <v-container>
+              <v-row>
+                <v-col
+                  cols="12"
+                >
+                  <v-row
+                    justify="center"
+                  >
+                    <v-avatar
+                      size="62"
+                    >
+                      <img
+                        v-if="otherUser.avatar_url"
+                        :src="otherUser"
+                      >
+                      <img
+                        v-else
+                        :src="icon"
+                      >
+                    </v-avatar>
+                  </v-row>
+                </v-col>
+                <v-col
+                  cols="12"
+                >
+                  <v-row
+                    justify="center"
+                  >
+                    <h3>{{ otherUser.name }} さん</h3>
+                  </v-row>
+                </v-col>
+                <v-col
+                  cols="12"
+                >
+                  <v-row
+                    justify="center"
+                  >
+                    <p>{{ otherUser.profile }}</p>
+                  </v-row>
+                </v-col>
+                <v-col
+                  cols="12"
+                >
+                  <v-row>
+                    <v-col>
+                      <p>フォロー</p>
+                      <p>{{ otherUser.following.length }}人</p>
+                    </v-col>
+                    <v-col>
+                      <p>フォロワー</p>
+                      <p>{{ otherUser.followers.length }}人</p>
+                    </v-col>
+                  </v-row>
+                </v-col>
+                <v-col
+                  v-if="myselfCheck"
+                  cols="12"
+                >
+                  <v-row
+                    justify="center"
+                  >
+                    <v-btn
+                      v-if="!otherUser.isFollowed"
+                      coloer="success"
+                      @click="follow"
+                    >
+                      フォローする
+                    </v-btn>
+                    <v-btn
+                      v-else
+                      collor="white--text red"
+                      @click="unfollow"
+                    >
+                      フォロー解除する
+                    </v-btn>
+                  </v-row>
+                </v-col>
+              </v-row>
+            </v-container>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      icon: require("@/assets/images/other/default-user.png")
+    }
+  },
+  computed: {
+    user() {
+      return this.$store.state.auth.currentUser
+    }
+  },
+}
+</script>

--- a/frontend/store/auth.js
+++ b/frontend/store/auth.js
@@ -2,6 +2,7 @@ export const state = () => ({
   loggedIn: false,
   currentUser: {},
   data: {},
+  users: {},
   styles: {
     beforeLogin: {
       appBarHeight: 56,
@@ -34,6 +35,18 @@ export const actions = {
   setLoginState(context, data) {
     context.commit('setLoginState', data)
   },
+  setUsers({ commit, rootState }, users) {
+    users.forEach((currentUser) => {
+      currentUser.isFollowed = false
+      if (rootState.auth.datas) {
+        currentUser.following.forEach((f) => {
+          if (f.id === rootState.auth.datas.id) {
+            currentUser.isFollowed = true
+          }
+        })
+      }
+    })
+  },
 }
 
 export const getters = {
@@ -42,5 +55,8 @@ export const getters = {
   },
   data(state) {
     return state.data
+  },
+  users(state) {
+    return state.users
   },
 }

--- a/frontend/store/auth.js
+++ b/frontend/store/auth.js
@@ -1,6 +1,7 @@
 export const state = () => ({
   loggedIn: false,
   currentUser: {},
+  data: {},
   styles: {
     beforeLogin: {
       appBarHeight: 56,
@@ -21,6 +22,9 @@ export const mutations = {
   setLoginState(state, payload) {
     state.loggedIn = payload
   },
+  setData(state, payload) {
+    state.data = payload
+  },
 }
 
 export const actions = {
@@ -35,5 +39,8 @@ export const actions = {
 export const getters = {
   currentUser(state) {
     return state.currentUser
+  },
+  data(state) {
+    return state.data
   },
 }

--- a/frontend/store/otherUser.js
+++ b/frontend/store/otherUser.js
@@ -1,0 +1,48 @@
+export const state = () => ({
+  user: {},
+  data: {},
+})
+
+export const getters = {
+  user: (state) => state.user,
+  data(state) {
+    return state.data
+  },
+}
+
+export const mutations = {
+  setUser(state, user) {
+    state.user = user
+  },
+  setData(state, payload) {
+    state.data = payload
+  },
+}
+
+export const actions = {
+  async getUser({ commit }, paramsId) {
+    await this.$axios
+      .$get(`/v1/users/${paramsId}`)
+      .then((res) => {
+        // eslint-disable-next-line no-console
+        console.log(res.data)
+        commit('setUser', res.data)
+      })
+      .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.log(err)
+        return err
+      })
+  },
+  setData({ commit, rootState }, auth) {
+    auth.isFollowed = false
+    if (rootState.auth.data) {
+      auth.followers.forEach((f) => {
+        if (f.id === rootState.auth.data.id) {
+          auth.isFollowed = true
+        }
+      })
+    }
+    commit('setData', auth)
+  },
+}

--- a/frontend/store/otherUser.js
+++ b/frontend/store/otherUser.js
@@ -22,20 +22,6 @@ export const mutations = {
 }
 
 export const actions = {
-  async getUser({ commit }, paramsId) {
-    await this.$axios
-      .$get(`/v1/users/${paramsId}`)
-      .then((res) => {
-        // eslint-disable-next-line no-console
-        console.log(res.data)
-        commit('setUser', res.data)
-      })
-      .catch((err) => {
-        // eslint-disable-next-line no-console
-        console.log(err)
-        return err
-      })
-  },
   setData({ commit, rootState }, auth) {
     auth.isFollowed = false
     if (rootState.auth.data) {

--- a/frontend/store/otherUser.js
+++ b/frontend/store/otherUser.js
@@ -1,6 +1,7 @@
 export const state = () => ({
   users: {},
   data: {},
+  otherUser: {},
 })
 
 export const getters = {
@@ -10,6 +11,9 @@ export const getters = {
   data(state) {
     return state.data
   },
+  otherUser(state) {
+    return state.otherUser
+  },
 }
 
 export const mutations = {
@@ -18,6 +22,9 @@ export const mutations = {
   },
   setData(state, auth) {
     state.data = auth
+  },
+  setOtherUser(state, payload) {
+    state.otherUser = payload
   },
 }
 
@@ -32,5 +39,8 @@ export const actions = {
       })
     }
     commit('setData', auth)
+  },
+  setOtherUser(context, data) {
+    context.commit('setOtherUser', data)
   },
 }

--- a/frontend/store/otherUser.js
+++ b/frontend/store/otherUser.js
@@ -1,21 +1,23 @@
 export const state = () => ({
-  user: {},
+  users: {},
   data: {},
 })
 
 export const getters = {
-  user: (state) => state.user,
+  users(state) {
+    return state.users
+  },
   data(state) {
     return state.data
   },
 }
 
 export const mutations = {
-  setUser(state, user) {
-    state.user = user
+  setUsers(state, users) {
+    state.users = users
   },
-  setData(state, payload) {
-    state.data = payload
+  setData(state, auth) {
+    state.data = auth
   },
 }
 

--- a/frontend/store/user.js
+++ b/frontend/store/user.js
@@ -1,0 +1,44 @@
+export const state = () => ({
+  user: {},
+  data: {},
+  users: {},
+})
+
+export const getters = {
+  user(state) {
+    return state.user
+  },
+  data(state) {
+    return state.data
+  },
+  users(state) {
+    return state.users
+  },
+}
+
+export const actions = {
+  setUser({ commit }, user) {
+    commit('setUser', user)
+  },
+  setUsers({ commit, rootState }, users) {
+    users.forEach((user) => {
+      user.isFollowed = false
+      if (rootState.user.data) {
+        user.following.forEach((f) => {
+          if (f.id === rootState.user.data.id) {
+            user.isFollowed = true
+          }
+        })
+      }
+    })
+  },
+}
+
+export const mutations = {
+  setUser(state, user) {
+    state.user = user
+  },
+  setData(state, payload) {
+    state.data = payload
+  },
+}

--- a/frontend/store/user.js
+++ b/frontend/store/user.js
@@ -1,44 +1,30 @@
 export const state = () => ({
   user: {},
-  data: {},
-  users: {},
 })
 
 export const getters = {
-  user(state) {
-    return state.user
-  },
-  data(state) {
-    return state.data
-  },
-  users(state) {
-    return state.users
-  },
-}
-
-export const actions = {
-  setUser({ commit }, user) {
-    commit('setUser', user)
-  },
-  setUsers({ commit, rootState }, users) {
-    users.forEach((user) => {
-      user.isFollowed = false
-      if (rootState.user.data) {
-        user.following.forEach((f) => {
-          if (f.id === rootState.user.data.id) {
-            user.isFollowed = true
-          }
-        })
-      }
-    })
-  },
+  user: (state) => state.user,
 }
 
 export const mutations = {
   setUser(state, user) {
     state.user = user
   },
-  setData(state, payload) {
-    state.data = payload
+}
+
+export const actions = {
+  async getUser({ commit }, paramsId) {
+    await this.$axios
+      .$get(`/v1/users/${paramsId}`)
+      .then((res) => {
+        // eslint-disable-next-line no-console
+        console.log(res.data)
+        commit('setUser', res.data)
+      })
+      .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.log(err)
+        return err
+      })
   },
 }


### PR DESCRIPTION
close #30

## 実装内容
- バックエンド
  - `relationship`コントローラ作成
  - `relationships`テーブル作成
  - `user`モデルにアソシエーション設定

- フロントエンド
  - フォロー/フォロワー機能のフロントエンド部分実装
  - マイページにフォローとフォロワー一覧タブを実装

## チェック項目
- バックエンド
- [ ] `rubocop -a` を実行し修正箇所が無いこと

- 全体
- [ ] ローカル環境での動作に問題無いこと