### PR TITLE
飲んだビールを記録する機能実装

### DIFF
--- a/backend/app/controllers/v1/memories_controller.rb
+++ b/backend/app/controllers/v1/memories_controller.rb
@@ -1,0 +1,23 @@
+module V1
+  class MemoriesController < ApplicationController
+    def index
+      memory = Memory.all
+      render json: memory
+    end
+
+    def create
+      memory = Memory.create!(memory_params)
+      if memory.save
+        render json: memory
+      else
+        render json: memory.errors
+      end
+    end
+
+    private
+
+    def memory_params
+      params.require(:memory).permit(:beer_name, :repeat, :user_id)
+    end
+  end
+end

--- a/backend/app/models/memory.rb
+++ b/backend/app/models/memory.rb
@@ -1,0 +1,2 @@
+class Memory < ApplicationRecord
+end

--- a/backend/app/models/memory.rb
+++ b/backend/app/models/memory.rb
@@ -1,2 +1,3 @@
 class Memory < ApplicationRecord
+  belongs_to :user
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   has_many :passive_relationships, class_name: 'Relationship', foreign_key: 'followed_id', dependent: :destroy
   has_many :following, through: :active_relationships, source: :followed
   has_many :followers, through: :passive_relationships, source: :follower
+  has_many :memories, dependent: :destroy
 
   # ユーザーをフォローする
   def follow(other_user)

--- a/backend/app/serializers/memory_serializer.rb
+++ b/backend/app/serializers/memory_serializer.rb
@@ -1,0 +1,8 @@
+class MemorySerializer < ActiveModel::Serializer
+  attributes :id, :beer_name, :repeat, :user_id, :username, :created_at
+  belongs_to :user
+
+  def username
+    object.user.name
+  end
+end

--- a/backend/app/serializers/user_serializer.rb
+++ b/backend/app/serializers/user_serializer.rb
@@ -1,4 +1,5 @@
 class UserSerializer < ActiveModel::Serializer
   attributes :id, :name, :email, :profile, :favorite_beer, :avatar, :following, :followers
   has_many :posts
+  has_many :memories
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -79,5 +79,8 @@ Rails.application.routes.draw do
 
     # relationships 関連
     resources :relationships, only: %i[create destroy]
+
+    # memories 関連
+    resources :memories, only: %i[index create]
   end
 end

--- a/backend/db/migrate/20220526112224_create_memories.rb
+++ b/backend/db/migrate/20220526112224_create_memories.rb
@@ -1,0 +1,11 @@
+class CreateMemories < ActiveRecord::Migration[6.1]
+  def change
+    create_table :memories do |t|
+      t.string :beer_name, null: false
+      t.string :repeat, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_20_130646) do
+ActiveRecord::Schema.define(version: 2022_05_26_112224) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,15 @@ ActiveRecord::Schema.define(version: 2022_05_20_130646) do
     t.string "image_url"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "memories", force: :cascade do |t|
+    t.string "beer_name", null: false
+    t.string "repeat", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_memories_on_user_id"
   end
 
   create_table "posts", force: :cascade do |t|
@@ -71,6 +80,7 @@ ActiveRecord::Schema.define(version: 2022_05_20_130646) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "memories", "users"
   add_foreign_key "posts", "users"
   add_foreign_key "reviews", "beers"
   add_foreign_key "reviews", "users"

--- a/frontend/components/loggedIn/mypage/memory.vue
+++ b/frontend/components/loggedIn/mypage/memory.vue
@@ -1,7 +1,8 @@
 <template>
   <v-container>
     <v-card
-      width="900"
+      v-if="user"
+      width="450"
       class="mx-auto"
     >
       <v-toolbar
@@ -16,13 +17,13 @@
       >
         <v-col
           cols="12"
-          sm="2"
+          sm="4"
         >
           <v-subheader>ビール一覧</v-subheader>
         </v-col>
         <v-col
           cols="12"
-          sm="6"
+          sm="7"
         >
           <v-select
             v-model="beerSelect"
@@ -41,13 +42,13 @@
       >
         <v-col
           cols="12"
-          sm="2"
+          sm="4"
         >
           <v-subheader right>リピート度合い</v-subheader>
         </v-col>
         <v-col
           cols="12"
-          sm="6"
+          sm="7"
         >
           <v-select
             v-model="repeatSelect"

--- a/frontend/components/loggedIn/mypage/memory.vue
+++ b/frontend/components/loggedIn/mypage/memory.vue
@@ -1,7 +1,5 @@
 <template>
-  <v-container
-    
-  >
+  <v-container>
     <v-card
       width="900"
       class="mx-auto"
@@ -11,7 +9,7 @@
         dark
         flat
       >
-        <v-toolbar-title>飲んだビールを登録する</v-toolbar-title>
+        <v-toolbar-title>{{ user.name }} が飲んだビールを登録する</v-toolbar-title>
       </v-toolbar>
       <v-row
         justify="center"
@@ -76,6 +74,7 @@
             block
             color="success"
             class="white--text"
+            @click="memorySubmit"
           >
             登録する
             <v-icon
@@ -95,13 +94,13 @@ export default {
   data () {
     return {
       beerSelect: '',
-      repeatSelect: [],
+      repeatSelect: '',
       beers: [],
       repeats: [
         { text: 'また購入する', value: 'また購入する' },
         { text: 'もしかしたら購入するかも', value: 'もしかしたら購入するかも' },
         { text: '悩み中', value: '悩み中' }
-      ]
+      ],
     }
   },
   async fetch () {
@@ -113,6 +112,16 @@ export default {
       return this.$store.state.auth.currentUser
     }
   },
+  methods: {
+    memorySubmit() {
+      const memory = {
+        beer_name: this.beerSelect,
+        repeat: this.repeatSelect,
+        user_id: this.user.id
+      }
+      this.$emit('submit', memory)
+    }
+  }
 }
 </script>
 

--- a/frontend/components/loggedIn/mypage/memory.vue
+++ b/frontend/components/loggedIn/mypage/memory.vue
@@ -1,3 +1,120 @@
 <template>
-  <div>飲んだビール</div>
+  <v-container
+    
+  >
+    <v-card
+      width="900"
+      class="mx-auto"
+    >
+      <v-toolbar
+        color="myorange lighten-1"
+        dark
+        flat
+      >
+        <v-toolbar-title>飲んだビールを登録する</v-toolbar-title>
+      </v-toolbar>
+      <v-row
+        justify="center"
+      >
+        <v-col
+          cols="12"
+          sm="2"
+        >
+          <v-subheader>ビール一覧</v-subheader>
+        </v-col>
+        <v-col
+          cols="12"
+          sm="6"
+        >
+          <v-select
+            v-model="beerSelect"
+            item-text="beer_name"
+            :items="beers"
+            :menu-props="{ maxHeight: '400'}"
+            label="Select"
+            hint="飲んだビールを選択してください"
+            prepend-icon="mdi-liquor"
+            persistent-hint
+          ></v-select>
+        </v-col>
+      </v-row>
+      <v-row
+        justify="center"
+      >
+        <v-col
+          cols="12"
+          sm="2"
+        >
+          <v-subheader right>リピート度合い</v-subheader>
+        </v-col>
+        <v-col
+          cols="12"
+          sm="6"
+        >
+          <v-select
+            v-model="repeatSelect"
+            :items="repeats"
+            :menu-props="{ maxHeight: '400' }"
+            label="Select"
+            hint="リピート度合いを選択してください"
+            prepend-icon="mdi-repeat"
+            persistent-hint
+          />
+        </v-col>
+      </v-row>
+      <v-card
+        width="320"
+        flat
+        color="transparent"
+        class="mx-auto"
+      >
+        <v-card-actions>
+          <v-btn
+            rounded
+            outlined
+            dark
+            block
+            color="success"
+            class="white--text"
+          >
+            登録する
+            <v-icon
+              right
+            >
+              mdi-book-open-variant
+            </v-icon>
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-card>
+  </v-container>
 </template>
+
+<script>
+export default {
+  data () {
+    return {
+      beerSelect: '',
+      repeatSelect: [],
+      beers: [],
+      repeats: [
+        { text: 'また購入する', value: 'また購入する' },
+        { text: 'もしかしたら購入するかも', value: 'もしかしたら購入するかも' },
+        { text: '悩み中', value: '悩み中' }
+      ]
+    }
+  },
+  async fetch () {
+    const beers = await this.$axios.$get('/v1/beers')
+    this.beers = beers
+  },
+  computed: {
+    user() {
+      return this.$store.state.auth.currentUser
+    }
+  },
+}
+</script>
+
+<style>
+</style>

--- a/frontend/components/loggedIn/mypage/memoryList.vue
+++ b/frontend/components/loggedIn/mypage/memoryList.vue
@@ -1,0 +1,99 @@
+<template>
+  <!-- <v-card
+    flat
+    color="transparent"
+    class="mx-auto"
+  >
+    <v-container>
+      <v-row
+        dense
+      >
+        <v-col
+          v-for="(memory, i) in memories"
+          :key="i"
+          cols="12"
+        >
+          <v-card
+            v-if="memory"
+            width="450"
+            class="mx-auto"
+          >
+            <v-row
+              justify="center"
+            >
+              <v-col
+                cols="12"
+                sm="6"
+              >
+                <li class="text-h5">飲んだビール</li>
+                <h4>{{ memory.beer_name }}</h4>
+              </v-col>
+              <v-col
+                cols="12"
+                sm="6"
+              >
+                <li class="text-h6">リピート度</li>
+                <h4>{{ memory.repeat }}</h4>
+              </v-col>
+            </v-row>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-container>
+  </v-card> -->
+  <v-row
+    justify="center"
+  >
+    <v-col
+      v-for="(memory, i) in memories"
+      :key="i"
+      cols="12"
+    >
+      <v-container>
+      <v-card
+        v-if="memory"
+        width="450"
+        class="mx-auto"
+      >
+        <v-row
+          dense
+        >
+        <v-col
+          cos="12"
+          sm="6"
+        >
+          <li class="text-h6">飲んだビール</li>
+          <h4>{{ memory.beer_name }}</h4>
+        </v-col>
+        <v-col
+          cols="12"
+          sm="6"
+        >
+          <li class="text-h6">リピート度</li>
+          <h4>{{ memory.repeat }}</h4>
+        </v-col>
+        </v-row>
+      </v-card>
+      </v-container>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+export default {
+  props: {
+    memories: {
+      type: Array,
+      default: () => {}
+    }
+  },
+  data () {
+    return {}
+  },
+  computed: {
+    user() {
+      return this.$store.state.auth.currentUser
+    }
+  },
+}
+</script>

--- a/frontend/components/memories/createMemoriesDialog.vue
+++ b/frontend/components/memories/createMemoriesDialog.vue
@@ -1,0 +1,26 @@
+<template>
+  <v-dialog
+    v-model="createMemoriesDialog"
+    width="500"
+  >
+    <v-card>
+      <!-- <div>
+        {{ beers }}
+      </div> -->
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+export default {
+  props: {
+    beers: {
+      type: Array,
+      default: () => {}
+    }
+  },
+  data: () => ({
+    createMemoriesDialog: false
+  })
+}
+</script>

--- a/frontend/pages/auth/mypage.vue
+++ b/frontend/pages/auth/mypage.vue
@@ -142,7 +142,7 @@
         <v-tab-item
           class="tab-item"
         >
-          <memory />
+          <memory @submit="addMemory"/>
         </v-tab-item>
       </v-tabs>
     </v-card>
@@ -202,6 +202,13 @@ export default {
         posts: [...this.user.posts, data]
       })
       location.reload()
+    },
+    async addMemory(memory) {
+      const { data } = await this.$axios.$post('/v1/memories', memory)
+      this.$store.dispatch('auth/setUser', {
+        ...this.user,
+        memories: [...this.user.memories, data]
+      })
     }
   }
 }

--- a/frontend/pages/auth/mypage.vue
+++ b/frontend/pages/auth/mypage.vue
@@ -143,6 +143,7 @@
           class="tab-item"
         >
           <memory @submit="addMemory"/>
+          <memory-list :memories="user.memories" />
         </v-tab-item>
       </v-tabs>
     </v-card>
@@ -155,6 +156,7 @@ import follow from '~/components/loggedIn/mypage/follow'
 import follower from '~/components/loggedIn/mypage/follower'
 import memory from '~/components/loggedIn/mypage/memory'
 import createPostsDialog from '~/components/posts/createPostsDialog'
+import memoryList from '~/components/loggedIn/mypage/memoryList'
 export default {
   components: {
     profile,
@@ -162,7 +164,8 @@ export default {
     follow,
     follower,
     memory,
-    createPostsDialog
+    createPostsDialog,
+    memoryList
   },
   layout: 'loggedIn',
   data () {
@@ -209,6 +212,7 @@ export default {
         ...this.user,
         memories: [...this.user.memories, data]
       })
+      location.reload()
     }
   }
 }


### PR DESCRIPTION
close #35

## 実装内容
- バックエンド
  - `memories`テーブル作成、migrate実行
  - `user`モデルとアソシエーションを設定
  - `memories_controller`作成

- フロントエンド
  - 飲んだビールを記録する表示内容を実装
  - バックエンドまでの登録処理を実装

## チェック項目
-  バックエンド
- [x] `rubocop -a`を実行し修正箇所が無いこと
- 全体
- [x] ローカル環境での動作に問題無いこと