### PR TITLE
退会機能実装

### DIFF
--- a/backend/app/controllers/v1/users_controller.rb
+++ b/backend/app/controllers/v1/users_controller.rb
@@ -58,6 +58,15 @@ module V1
       end
     end
 
+    def destroy
+      user = User.find(params[:id])
+      if user.destroy
+        render json: user
+      else
+        render json: user.errors
+      end
+    end
+
     private
 
     def user_params

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   namespace :v1 do
     # user関連
     patch 'users/:id/avatar_update', to: 'users#avatar_update'
-    resources :users, only: %i[index show create update]
+    resources :users, only: %i[index show create update destroy]
 
     # beer関連
     # beer_style

--- a/frontend/pages/auth/edit.vue
+++ b/frontend/pages/auth/edit.vue
@@ -83,12 +83,26 @@
             アイコン更新
           </v-btn>
         </v-card-actions>
+        <v-card-actions>
+          <v-btn
+            rounded
+            outlined
+            block
+            dark
+            color="red"
+            class="ml-2 font-weight-bold"
+            @click="deleteAccount"
+          >
+            退会する
+          </v-btn>
+        </v-card-actions>
       </v-card>
     </v-row>
   </v-container>
 </template>
 
 <script>
+import firebase from '~/plugins/firebase'
 export default {
   layout: 'loggedIn',
   async asyncData({ $axios, store }) {
@@ -119,7 +133,8 @@ export default {
       profileRules: [
         v => !!v || '',
         v => (!!v && profileMax >= v.length) || `${profileMax}文字以内で入力してください`
-      ]
+      ],
+      userId: ''
     }
   },
   computed: {
@@ -176,6 +191,22 @@ export default {
         .catch((error) => {
           alert(error.message)
         })
+    },
+    async deleteAccount() {
+      const response = confirm("退会しますか？")
+      if (response) {
+        const user = await firebase.auth().currentUser
+        user.delete()
+          .then(() => {
+            this.$axios.$delete(`/v1/users/${this.userId}`)
+          })
+            .then(() => {
+              firebase.auth().signOut()
+              this.$store.dispatch('auth/setUser', null)
+              this.$store.dispatch('auth/setLoginState', false)
+              this.$router.push('/')
+            })
+      }
     }
   }
 }


### PR DESCRIPTION
close #43

## 実装内容
- バックエンド
  - `users_controller`に`destroy`メソッド作成
  - `destroy`メソッドのルーティング設定
  
- フロントエンド
  - 退会するためのボタン実装
  - ボタンクリック時のバックエンドのつなぎ込み実装

## チェック項目
- バックエンド
- [x] `rubocop -a`を実行し修正箇所が無いこと
- フロントエンド
- [ ] ローカル環境での動作に問題無いこと